### PR TITLE
Fix playfab plugin naming in build.cs

### DIFF
--- a/Game/Source/GDKShooter/GDKShooter.Build.cs
+++ b/Game/Source/GDKShooter/GDKShooter.Build.cs
@@ -27,7 +27,7 @@ public class GDKShooter : ModuleRules
                 "JsonUtilities",
                 "HTTP",
                 "AIModule",
-                "Playfab",
+                "PlayFab",
                 "PlayFabCpp",
                 "LoginFlow"
             });


### PR DESCRIPTION
This fixes the build for workers on Linux (case-sensitive path names).